### PR TITLE
Redesign Django example app to use custom auth backend 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore virtual environment files
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore virtual environment files
 .venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-1. Ensure `CLERK_JWKS_URL` is set in your environment variables. This is the URL that Clerk uses to verify JWTs. This can be found in clerk dashboard under `"Configure" -> "Developers" -> "API keys" -> "JWKS URL"`
+1. Ensure `CLERK_API_SECRET_KEY` and `CLERK_AUTHORIZED_PARTIES` is set in your environment variables. `CLERK_AUTHORIZED_PARTIES` is a comma-separated list of allowed parties for example `http://localhost:5173`
 
 2. Install dependencies with `pip install -r requirements.txt`
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 1. Ensure `CLERK_API_SECRET_KEY` and `CLERK_AUTHORIZED_PARTIES` is set in your environment variables. `CLERK_AUTHORIZED_PARTIES` is a comma-separated list of allowed parties for example `http://localhost:5173`
 
-2. Install dependencies with `pip install -r requirements.txt`
+2. Install dependencies with 
+```commandline
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
 
 3. Run `python3 manage.py runserver`
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,92 @@
-1. Ensure `CLERK_API_SECRET_KEY` and `CLERK_AUTHORIZED_PARTIES` is set in your environment variables. `CLERK_AUTHORIZED_PARTIES` is a comma-separated list of allowed parties for example `http://localhost:5173`
+# Django Clerk Auth Example
 
-2. Install dependencies with 
+A demonstration of using Clerk JWT authentication with Django. This example shows how to integrate Clerk's user authentication with a Django backend API.
+
+## Installation 
+
 ```commandline
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3. Run `python3 manage.py runserver`
+## Configuration
 
-4. From a Clerk frontend, use the `useSession` hook to retrieve the getToken() function:
+Set the required environment variables:
 
+```bash
+$ export CLERK_API_SECRET_KEY=your_secret_key
+
+# Set authorized parties (comma-separated list of allowed origins)
+$ export CLERK_AUTHORIZED_PARTIES=http://localhost:5173
 ```
-const { getToken } = useSession();
+
+## Running 
+
+```commandline
+python manage.py runserver
 ```
 
-5. Then, request the python server with:
+The server will be running at `http://localhost:8000`.
 
-```
-await fetch("http://localhost:8000/clerk_jwt", {
-    headers: {
-        "Authorization": `Bearer ${await getToken()}`
+## Frontend Integration
+
+From a Clerk React frontend:
+
+```javascript
+import { useAuth } from '@clerk/clerk-react';
+
+function ApiExample() {
+  const { getToken } = useAuth();
+  
+  const fetchData = async () => {
+    if (getToken) {
+      // Get the userId or null if the token is invalid
+      let res = await fetch("http://localhost:8000/clerk_jwt", {
+          headers: {
+              "Authorization": `Bearer ${await getToken()}`
+          }
+      });
+      console.log(await res.json()); // {userId: 'the_user_id_or_null'}
+
+      // Get gated data or a 401 Unauthorized if the token is not valid
+      res = await fetch("http://localhost:8000/gated_data", {
+          headers: {
+              "Authorization": `Bearer ${await getToken()}`
+          }
+      });
+      if (res.ok) {
+          console.log(await res.json()); // {foo: "bar"}
+      } else {
+          // Token was invalid
+      }
     }
-})
+  };
+  
+  return <button onClick={fetchData}>Fetch Data</button>;
+}
 ```
 
+## API Reference
 
-## Important Note:
-This project is not optimized for production and do not address all best practices that should be configured in a production app (CORS, 401 error handling and HTTPs for example).
-These projects serve as a design template and should be given appropriate consideration before being used in production.
+Available endpoints:
+
+- `GET /clerk_jwt` - Returns the authenticated user ID
+- `GET /gated_data` - Returns protected data (requires authentication)
+
+
+## ⚠️ Production Warning
+
+This project is not optimized for production and does not address all best practices that should be configured in a production app. It serves as a design template and should be given appropriate consideration before being used in production.
+
+Issues to address for production use:
+- CORS configuration is specific to development environments
+- No HTTPS enforcement
+- Minimal error handling (especially 401 errors)
+- Using development server settings
+
+For production deployment:
+1. Configure proper CORS settings for your specific domains
+2. Enforce HTTPS for all API communication
+3. Implement comprehensive error handling
+4. Use a production-grade web server instead of the built-in development server

--- a/README.md
+++ b/README.md
@@ -2,14 +2,6 @@
 
 A demonstration of using Clerk JWT authentication with Django. This example shows how to integrate Clerk's user authentication with a Django backend API.
 
-## Installation 
-
-```commandline
-python -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
-```
-
 ## Configuration
 
 Set the required environment variables:
@@ -19,6 +11,14 @@ $ export CLERK_API_SECRET_KEY=your_secret_key
 
 # Set authorized parties (comma-separated list of allowed origins)
 $ export CLERK_AUTHORIZED_PARTIES=http://localhost:5173
+```
+
+## Installation 
+
+```commandline
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
 ```
 
 ## Running 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-Run `python3 manage.py runserver`
+1. Ensure `CLERK_JWKS_URL` is set in your environment variables. This is the URL that Clerk uses to verify JWTs. This can be found in clerk dashboard under `"Configure" -> "Developers" -> "API keys" -> "JWKS URL"`
 
-From a Clerk frontend, use the `useSession` hook to retrieve the getToken() function:
+2. Install dependencies with `pip install -r requirements.txt`
+
+3. Run `python3 manage.py runserver`
+
+4. From a Clerk frontend, use the `useSession` hook to retrieve the getToken() function:
 
 ```
 const { getToken } = useSession();
 ```
 
-Then, request the python server with:
+5. Then, request the python server with:
 
 ```
 await fetch("http://localhost:8000/clerk_jwt", {
@@ -15,3 +19,8 @@ await fetch("http://localhost:8000/clerk_jwt", {
     }
 })
 ```
+
+
+## Important Note:
+This project is not optimized for production and do not address all best practices that should be configured in a production app (CORS, 401 error handling and HTTPs for example).
+These projects serve as a design template and should be given appropriate consideration before being used in production.

--- a/clerkapp/auth.py
+++ b/clerkapp/auth.py
@@ -1,12 +1,10 @@
-import json
 from functools import wraps
-from urllib.request import urlopen
 
+from clerk_backend_api import authenticate_request, AuthenticateRequestOptions
 from django.contrib.auth import authenticate
 from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.models import User
 from django.http import JsonResponse
-from jose import jwt
 
 from clerkproject import settings
 
@@ -16,24 +14,23 @@ class JwtAuthBackend(BaseBackend):
         if 'Authorization' not in request.headers:
             return None
 
-        # Strip the "Bearer " prefix from the header
-        token = request.headers['Authorization'][7:]
-
-        if not token:
-            raise None
-
         try:
-            url = settings.CLERK_JWKS_URL
-            response = urlopen(url)
-            data_json = json.loads(response.read())
-            decoded = jwt.decode(token, data_json['keys'][0], algorithms=['RS256'])
+            request_state = authenticate_request(
+                request,
+                AuthenticateRequestOptions(
+                    secret_key=settings.CLERK_API_SECRET_KEY,
+                    authorized_parties=settings.CLERK_AUTHORIZED_PARTIES,
+                ),
+            )
+            if request_state.reason:
+                return None
+            # Ideally at this point user object must be fetched from DB and returned, but we will just return a dummy
+            # user object
+            user = User(username=request_state.payload["sub"], password="None")
+            return user
+
         except Exception:
             return None
-
-        # Ideally at this point user object must be fetched from DB and returned, but we will just return a dummy
-        # user object
-        user = User(username=decoded['sub'], password="None")
-        return user
 
     def get_user(self, user_id):
         return User(username=user_id, password="None")

--- a/clerkapp/auth.py
+++ b/clerkapp/auth.py
@@ -1,0 +1,51 @@
+import json
+from functools import wraps
+from urllib.request import urlopen
+
+from django.contrib.auth import authenticate
+from django.contrib.auth.backends import BaseBackend
+from django.contrib.auth.models import User
+from django.http import JsonResponse
+from jose import jwt
+
+from clerkproject import settings
+
+
+class JwtAuthBackend(BaseBackend):
+    def authenticate(self, request, **kwargs):
+        if 'Authorization' not in request.headers:
+            return None
+
+        # Strip the "Bearer " prefix from the header
+        token = request.headers['Authorization'][7:]
+
+        if not token:
+            raise None
+
+        try:
+            url = settings.CLERK_JWKS_URL
+            response = urlopen(url)
+            data_json = json.loads(response.read())
+            decoded = jwt.decode(token, data_json['keys'][0], algorithms=['RS256'])
+        except Exception:
+            return None
+
+        # Ideally at this point user object must be fetched from DB and returned, but we will just return a dummy
+        # user object
+        user = User(username=decoded['sub'], password="None")
+        return user
+
+    def get_user(self, user_id):
+        return User(username=user_id, password="None")
+
+
+def jwt_required(view_func):
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        user = authenticate(request)
+        if not user:
+            return JsonResponse({'error': 'User not authenticated'}, status=401)
+        request.user = user
+        return view_func(request, *args, **kwargs)
+
+    return _wrapped_view

--- a/clerkapp/urls.py
+++ b/clerkapp/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import clerk_jwt
+from .views import clerk_jwt, gated_data
 
 urlpatterns = [
     path('clerk_jwt/', clerk_jwt),
+    path('gated_data/', gated_data),
 ]

--- a/clerkapp/views.py
+++ b/clerkapp/views.py
@@ -1,24 +1,19 @@
-from django.shortcuts import render
 from django.http import JsonResponse
-from jose import jwt
 
-from urllib.request import urlopen
-import json
+from clerkapp.auth import jwt_required
 
+
+@jwt_required
 def clerk_jwt(request):
-    # Strip the "Bearer " prefix from the header
-    token = request.headers['Authorization'][7:]
-
-    # Update this to 'https://{clerk_frontend_api}/.well-known/jwks.json'
-    # Note: The content of this endpoint will never change, so it should
-    # be cached on the server instead of requested with each API call
-    url = 'https://clerk.clerk.dev/.well-known/jwks.json'
-    response = urlopen(url)
-    data_json = json.loads(response.read())
-
-    decoded = jwt.decode(token, data_json['keys'][0], algorithms=['RS256'])
-
     data = {
-        'userId': decoded['sub'],
+        'userId': request.user.username,
+    }
+    return JsonResponse(data)
+
+
+@jwt_required
+def gated_data(request):
+    data = {
+        "foo": "bar",
     }
     return JsonResponse(data)

--- a/clerkproject/settings.py
+++ b/clerkproject/settings.py
@@ -18,7 +18,8 @@ load_dotenv()
 CLERK_API_SECRET_KEY = os.getenv('CLERK_API_SECRET_KEY')
 
 # comma separated list of authorized parties
-CLERK_AUTHORIZED_PARTIES = os.getenv('CLERK_AUTHORIZED_PARTIES')
+CLERK_AUTHORIZED_PARTIES = os.getenv("CLERK_AUTHORIZED_PARTIES").split(",") if os.getenv('CLERK_AUTHORIZED_PARTIES') else []
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -64,7 +65,8 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware'
 ]
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = CLERK_AUTHORIZED_PARTIES
+
 
 ROOT_URLCONF = 'clerkproject.urls'
 

--- a/clerkproject/settings.py
+++ b/clerkproject/settings.py
@@ -11,6 +11,11 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+CLERK_JWKS_URL = os.getenv('CLERK_JWKS_URL')
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -38,6 +43,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'corsheaders'
+]
+
+AUTHENTICATION_BACKENDS = [
+    'clerkapp.auth.JwtAuthBackend',
+    'django.contrib.auth.backends.ModelBackend'
 ]
 
 MIDDLEWARE = [

--- a/clerkproject/settings.py
+++ b/clerkproject/settings.py
@@ -15,7 +15,10 @@ from dotenv import load_dotenv
 import os
 
 load_dotenv()
-CLERK_JWKS_URL = os.getenv('CLERK_JWKS_URL')
+CLERK_API_SECRET_KEY = os.getenv('CLERK_API_SECRET_KEY')
+
+# comma separated list of authorized parties
+CLERK_AUTHORIZED_PARTIES = os.getenv('CLERK_AUTHORIZED_PARTIES')
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Django==4.2.20
+python-jose
+django-cors-headers
+python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==4.2.20
-python-jose
 django-cors-headers
 python-dotenv
+clerk-backend-api


### PR DESCRIPTION
This PR now uses custom authentication backend for verifying this requests with Clerk Auth. It also uses custom jwt_required decorator to do the authentication , a replacement for Django's login_required decorator. 